### PR TITLE
simplified export of packed blender images

### DIFF
--- a/io_mesh_urho/__init__.py
+++ b/io_mesh_urho/__init__.py
@@ -909,12 +909,7 @@ def ExecuteUrhoExport(context):
                     filename = os.path.join(texturesPath, textureName)                
                     
                     if image.packed_file:
-                        originalPath = image.filepath
-                        image.filepath = filename
-                        image.save()
-                        # TODO: this gives errors if the path does not exist. 
-                        # What to do? set it to None? replace with the new?
-                        image.filepath = originalPath  
+                        image.save_render(filename)
                         log.info( "Texture unpacked {:s}".format(filename) )
                     elif not os.path.exists(srcFilename):
                         log.error( "Cannot find texture {:s}".format(srcFilename) )


### PR DESCRIPTION
potentially the correct way of saving a packed blender image out, which doesn't require us having to patch the image file path (in between saves).  I was having difficulty exporting packed images with the previous code (and wishing Blender's api documentation was easier to navigate...).

My first pull request ever!  Would be ever so grateful if you could review this teeny,tiny change.

Thanks.
