### PR TITLE
Proposed fix for #36

### DIFF
--- a/io_mesh_urho/__init__.py
+++ b/io_mesh_urho/__init__.py
@@ -1300,9 +1300,11 @@ def ExecuteUrhoExport(context):
                     continue
                 # Get the texture file full path
                 srcFilename = bpy.path.abspath(image.filepath)
+		# Get image filename
+                filename = os.path.basename(image.filepath) 
                 # Get the destination file full path (preserve the extension)
                 fOptions.preserveExtTemp = True
-                filepath = GetFilepath(PathType.TEXTURES, textureName, fOptions)
+                filepath = GetFilepath(PathType.TEXTURES, filename, fOptions)
                 # Check if already exported
                 if not uScene.AddFile(PathType.TEXTURES, textureName, filepath[1]):
                     continue


### PR DESCRIPTION
Change image filepath to use real filename. It's using os.path.basename(). 
It should be okay on Linux because Blender always adapt it's path string depend on the os.
