### PR TITLE
Avoid Techniques folder by default

### DIFF
--- a/io_mesh_urho/export_urho.py
+++ b/io_mesh_urho/export_urho.py
@@ -1186,9 +1186,9 @@ def UrhoExport(tData, uExportOptions, uExportData, errorsMem):
         isEmissive = False
         emissiveTexture = None
         
-        technique = "Techniques/NoTexture"
+        technique = "NoTexture"
         if tMaterial.diffuseTexName:
-            technique = "Techniques/Diff"
+            technique = "Diff"
             if tMaterial.normalTexName:
                 technique += "Normal"
             if tMaterial.specularTexName:


### PR DESCRIPTION
The Techniques folder is always written in the path with NoTexture and Diff, even when the Techniques field is filled in settings, p.e. MyTechniques/Techniques/NoTexture.xml.
