### PR TITLE
Lightmap cannot paired with other textures except Diffuse

### DIFF
--- a/io_mesh_urho/export_urho.py
+++ b/io_mesh_urho/export_urho.py
@@ -1186,9 +1186,9 @@ def UrhoExport(tData, uExportOptions, uExportData, errorsMem):
         isEmissive = False
         emissiveTexture = None
         
-        technique = "NoTexture"
+        technique = "Techniques/NoTexture"
         if tMaterial.diffuseTexName:
-            technique = "Diff"
+            technique = "Techniques/Diff"
             # Lightmap cannot paired with other textures except Diffuse
             if tMaterial.lightmapTexName:
                 technique += "LightMap"


### PR DESCRIPTION
Before this change, if there's Lightmap and normal map, exporter will use DiffNormalLightmap technique which is non existent in default Urho3D installation.
