### PR TITLE
This script exports Blender scene objects into DXF file. 

### DIFF
--- a/README
+++ b/README
@@ -3,4 +3,20 @@ Urho3D-Blender
 
 Blender (http://www.blender.org) to Urho3D (https://github.com/urho3d/Urho3D) mesh exporter.
 
-See 'guide.txt' for the instructions.
+Download:
+https://github.com/reattiva/Urho3D-Blender/releases/download/latest/io_mesh_urho.zip
+
+Guide:
+https://github.com/reattiva/Urho3D-Blender/blob/master/guide.txt
+
+Installation:
+- download the zip file above
+- menu "File"
+- select "User Preferences..."
+- select page "Add-ons"
+- click "Install from File..." (lower toolbar)
+- select the downloaded zip file
+- in the addons list search for "Import-Export: Urho3D export"
+- enable it
+
+The addon is located in the "Properties" panel, at the end of the "Render" page (camera icon).

--- a/guide.txt
+++ b/guide.txt
@@ -1,19 +1,25 @@
 
-io_mesh_urho v0.5
+io_mesh_urho v0.6
 
 This is a Blender addon that helps you exporting your meshes, armatures, animations and materials to Urho3D.
 It is an amateur work, done with little knowledge of Urho3D and Blender, but I hope it helps.
 Public domain license. Maintained by reattiva (you can contact me @gmail.com).
 
- Installation
---------------
-- download the zip file from GitHub and unzip it;
+ Installation from releases
+----------------------------
+- download the latest zip file from the releases
+- jump to the plus below
+
+ Installation from GitHub zips
+-------------------------------
+- download the zip file from GitHub repository main page using the button "Download ZIP";
+- unzip it;
 - select the folder 'io_mesh_urho' and re-create a zip file (you need the folder 'io_mesh_urho' in the zip file);
-- open Blender;
++ open Blender;
 - open 'user preferences' (Ctrl+Alt+U);
 - click 'Addons' on the top bar;
 - click 'Install from file...' on the bottom bar;
-- select your created zip file;
+- select the zip file;
 - now search in the list, you should see a greyed line named 'Import-Export: Urho3D export';
 - click on the checkbox on the right to enable the addon (see below if you can't set the check);
 - optional: click 'Save User Settings' to remember this addon as enabled.
@@ -62,7 +68,7 @@ Set the meshes origin:
   'Global': the origin of all the meshes will be the Blender global origin (the center of the grid), meshes are kept in place.
   'Local': for each mesh the origin will be the object center (little orange dot), mesh is moved to (0,0,0).
 - Front view
-Allows to alter the rotation of the models at export.
+Allows to alter the rotation of the models.
 - Scale
 Apply a scale transformation on the object exported.
 - Apply Modifiers
@@ -105,8 +111,23 @@ Export the armature animations. Only available when 'Skeletons' option is checke
   'All Strips'
   'Selected Tracks'
   'Selected Strips'
+  'Selected Strips Actions'
   'Actions used in tracks'
   'All Actions'
+  - Start at frame zero: long story short, disable (uncheck) this option.
+  If checked this option use frame zero as start. If you have a keyframe at frame zero it should work without problems,
+  but if you don't, then in the frames between 0 and the first keyframe you can see some strange movements and rotations.
+  If unchecked (recommended), the start on the animation is the first keyframe of an Actions or the playback start frame 
+  for Tracks and the Timeline.
+  Using zero as start is probably a bug, however for backward compatibility this option is present and enabled by default. 
+  - Export markers as triggers: for each exported animation which contains markers a xml file is created where the time 
+  in seconds and the name of the markers are listed. This xml file can be used in Urho as triggers to signal particular 
+  keyframe of the animation. For the Timeline only 'Scene Markers' are exported. To add a 'Scene Marker' go to the Timeline 
+  or the NLA Editor window, then from the menu Marker, select Add Marker (M). Instead Actions, Strips and Tracks export 
+  'Pose Markers'. To add a 'Pose Marker' go to the Dope Sheet, select the Action Editor, create or load an Action, then 
+  from the menu Marker, select 'Show Pose Marker' and finally select Add Marker (M).
+    - Normalize Time: in the xml file, instead of the number of seconds, use a number from 0 (at the start of the 
+      animation) to 1 (at the end)
   - Only keyed bones: export only animation of bones with an animation key.
   - Position, Rotation, Scale: select what animation data to export.
 - Geometries

--- a/io_mesh_urho/__init__.py
+++ b/io_mesh_urho/__init__.py
@@ -298,6 +298,7 @@ class UrhoExportSettings(bpy.types.PropertyGroup):
 
         self.animations = False
         self.animationSource = 'USED_ACTIONS'
+        self.animationZero = True
         self.animationTriggers = False
         self.animationRatioTriggers = False
         self.animationPos = True
@@ -554,6 +555,12 @@ class UrhoExportSettings(bpy.types.PropertyGroup):
                     ('TIMELINE', "Timelime", "Export the timeline (NLA tracks sum)")),
             default = 'USED_ACTIONS',
             update = update_func)
+
+    animationZero = BoolProperty(
+            name = "Start at frame zero",
+            description = "Force frame zero as the start of Actions, Tracks and Timeline. Otherwise use the first keyframe "
+                          "for Actions or the playback start for Tracks and Timeline (Strips can only use their start)",
+            default = True)
 
     animationTriggers = BoolProperty(
             name = "Export markers as triggers",
@@ -916,6 +923,7 @@ class UrhoExportRenderPanel(bpy.types.Panel):
             row.separator()
             column = row.column()
             column.prop(settings, "animationSource")
+            column.prop(settings, "animationZero")
             column.prop(settings, "animationTriggers")
             if settings.animationTriggers:
                 row = column.row()
@@ -1198,6 +1206,7 @@ def ExecuteUrhoExport(context):
     tOptions.doTracks = (settings.animationSource == 'ALL_TRACKS')
     tOptions.doTimeline = (settings.animationSource == 'TIMELINE')
     tOptions.doTriggers = settings.animationTriggers
+    tOptions.doAnimationZero = settings.animationZero
     tOptions.doAnimationPos = settings.animationPos
     tOptions.doAnimationRot = settings.animationRot
     tOptions.doAnimationSca = settings.animationSca

--- a/io_mesh_urho/__init__.py
+++ b/io_mesh_urho/__init__.py
@@ -285,6 +285,7 @@ class UrhoExportSettings(bpy.types.PropertyGroup):
         addonPrefs = context.user_preferences.addons[__name__].preferences
 
         self.minimize = False
+        self.onlyErrors = False
         self.showDirs = False
 
         self.useSubDirs = True
@@ -369,6 +370,11 @@ class UrhoExportSettings(bpy.types.PropertyGroup):
     minimize = BoolProperty(
             name = "Minimize",
             description = "Minimize the export panel",
+            default = False)
+
+    onlyErrors = BoolProperty(
+            name = "Log errors",
+            description = "Show only warnings and errors in the log",
             default = False)
 
     showDirs = BoolProperty(
@@ -846,6 +852,7 @@ class UrhoExportRenderPanel(bpy.types.Panel):
         #split = layout.split(percentage=0.1)
         if sys.platform.startswith('win'):
             row.operator("wm.console_toggle", text="", icon='CONSOLE')
+        row.prop(settings, "onlyErrors", text="", icon='FORCE_WIND')
         row.operator("urho.report", text="", icon='TEXT')
         if settings.minimize:
             return
@@ -1290,6 +1297,11 @@ def ExecuteUrhoExport(context):
 
     settings.errorsMem.Clear()
 
+    if settings.onlyErrors:
+        log.setLevel(logging.WARNING)
+    else:
+        log.setLevel(logging.DEBUG)
+
     if not settings.outputPath:
         log.error( "Output path is not set" )
         return False
@@ -1422,6 +1434,7 @@ def ExecuteAddon(context):
     startTime = time.time()
     print("----------------------Urho export start----------------------")    
     ExecuteUrhoExport(context)
+    log.setLevel(logging.DEBUG)
     log.info("Export ended in {:.4f} sec".format(time.time() - startTime) )
     
     bpy.ops.urho.report('INVOKE_DEFAULT')

--- a/io_mesh_urho/__init__.py
+++ b/io_mesh_urho/__init__.py
@@ -170,6 +170,17 @@ class UrhoAddonPreferences(bpy.types.AddonPreferences):
             description = "Scenes subpath (relative to output)",
             default = "Scenes")
 
+    bonesPerGeometry = IntProperty(
+            name = "Per geometry",
+            description = "Max numbers of bones per geometry",
+            min = 64, max = 2048,
+            default = 64)
+    bonesPerVertex = IntProperty(
+            name = "Per vertex",
+            description = "Max numbers of bones per vertex",
+            min = 4, max = 256,
+            default = 4)
+
     reportWidth = IntProperty(
             name = "Window width",
             description = "Width of the report window",
@@ -190,6 +201,10 @@ class UrhoAddonPreferences(bpy.types.AddonPreferences):
         layout.prop(self, "texturesPath")
         layout.prop(self, "objectsPath")
         layout.prop(self, "scenesPath")
+        row = layout.row()
+        row.label("Max number of bones:")
+        row.prop(self, "bonesPerGeometry")
+        row.prop(self, "bonesPerVertex")
         row = layout.row()
         row.label("Report window:")
         row.prop(self, "reportWidth")
@@ -1182,6 +1197,9 @@ def ExecuteUrhoExport(context):
     # Scene export options
     sOptions = SOptions()
     
+    # Addons preferences
+    addonPrefs = context.user_preferences.addons[__name__].preferences
+    
     # Copy from exporter UI settings to Decompose options
     tOptions.mergeObjects = settings.merge
     tOptions.mergeNotMaterials = settings.mergeNotMaterials
@@ -1297,6 +1315,8 @@ def ExecuteUrhoExport(context):
         uExportOptions.splitSubMeshes = settings.geometrySplit
         uExportOptions.useStrictLods = settings.strictLods
         uExportOptions.useRatioTriggers = settings.animationRatioTriggers
+        uExportOptions.bonesPerGeometry = addonPrefs.bonesPerGeometry
+        uExportOptions.bonesPerVertex = addonPrefs.bonesPerVertex
 
         if DEBUG: ttt = time.time() #!TIME
         UrhoExport(tData, uExportOptions, uExportData, settings.errorsMem)

--- a/io_mesh_urho/__init__.py
+++ b/io_mesh_urho/__init__.py
@@ -548,6 +548,7 @@ class UrhoExportSettings(bpy.types.PropertyGroup):
             name = "",
             items = (('ALL_ACTIONS', "All Actions", "Export all the actions in memory"),
                     ('USED_ACTIONS', "Actions used in tracks", "Export only the actions used in NLA tracks"),
+                    ('SELECTED_ACTIONS', "Selected Strips' Actions", "Export the actions of the current selected NLA strips"),
                     ('SELECTED_STRIPS', "Selected Strips", "Export the current selected NLA strips"),
                     ('SELECTED_TRACKS', "Selected Tracks", "Export the current selected NLA tracks"),
                     ('ALL_STRIPS', "All Strips", "Export all NLA strips"),
@@ -1200,6 +1201,7 @@ def ExecuteUrhoExport(context):
     tOptions.doAnimations = settings.animations
     tOptions.doAllActions = (settings.animationSource == 'ALL_ACTIONS')
     tOptions.doUsedActions = (settings.animationSource == 'USED_ACTIONS')
+    tOptions.doSelectedActions = (settings.animationSource == 'SELECTED_ACTIONS')
     tOptions.doSelectedStrips = (settings.animationSource == 'SELECTED_STRIPS')
     tOptions.doSelectedTracks = (settings.animationSource == 'SELECTED_TRACKS')
     tOptions.doStrips = (settings.animationSource == 'ALL_STRIPS')

--- a/io_mesh_urho/__init__.py
+++ b/io_mesh_urho/__init__.py
@@ -26,7 +26,7 @@ bl_info = {
     "name": "Urho3D export",
     "description": "Urho3D export",
     "author": "reattiva",
-    "version": (0, 5),
+    "version": (0, 6),
     "blender": (2, 66, 0),
     "location": "Properties > Render > Urho export",
     "warning": "big bugs, use at your own risk",

--- a/io_mesh_urho/__init__.py
+++ b/io_mesh_urho/__init__.py
@@ -595,7 +595,7 @@ class UrhoExportSettings(bpy.types.PropertyGroup):
 
     geometryNor = BoolProperty(
             name = "Normal",
-            description = "Within geometry export vertex normal",
+            description = "Within geometry export vertex normal (enable 'Auto Smooth' to export custom normals)",
             default = True,
             update = update_func)
 

--- a/io_mesh_urho/decompose.py
+++ b/io_mesh_urho/decompose.py
@@ -345,6 +345,7 @@ class TOptions:
         self.doAnimations = True
         self.doAllActions = True
         self.doUsedActions = False
+        self.doSelectedActions = False
         self.doSelectedStrips = False
         self.doSelectedTracks = False
         self.doStrips = False
@@ -1200,6 +1201,9 @@ def DecomposeActions(scene, armatureObj, tData, tOptions):
             # Add an used Action
             action = strip.action
             if tOptions.doUsedActions and action and not action in animationObjects:
+                animationObjects.append(action)
+            # Add Actions of selected Strips
+            if tOptions.doSelectedActions and strip.select and action and not action in animationObjects:
                 animationObjects.append(action)
             previous = strip
                 

--- a/io_mesh_urho/decompose.py
+++ b/io_mesh_urho/decompose.py
@@ -1677,14 +1677,15 @@ def DecomposeMesh(scene, meshObj, tData, tOptions, errorsMem):
 
             position = posMatrix * vertex.co
 
-            # Split normal vector
-            normal = Vector(face.split_normals[i])
-            
-            # if face is smooth use vertex normal else use face normal
-            ##if face.use_smooth:
-            ##    normal = vertex.normal
-            ##else:
-            ##    normal = face.normal
+            if mesh.use_auto_smooth:
+                # if using Data->Normals->Auto Smooth, use split normal vector
+                normal = Vector(face.split_normals[i])
+            elif face.use_smooth:
+                # if face is smooth, use vertex normal
+                normal = vertex.normal
+            else:
+                # use face normal
+                normal = face.normal
             normal = normalMatrix * normal
             
             # Create a new vertex
@@ -1883,8 +1884,10 @@ def DecomposeMesh(scene, meshObj, tData, tOptions, errorsMem):
 
         # Recalculate normals
         shapeMesh.update(calc_edges = True, calc_tessface = True)
-        ##shapeMesh.calc_tessface()
-        ##shapeMesh.calc_normals()
+
+        # Compute local space unit length split normals vectors
+        shapeMesh.calc_normals_split()
+        shapeMesh.calc_tessface()
         
         # TODO: if set use 'vertex group' of the shape to filter affected vertices
         # TODO: can we use mesh tessfaces and not shapeMesh tessfaces ?
@@ -1908,10 +1911,14 @@ def DecomposeMesh(scene, meshObj, tData, tOptions, errorsMem):
                 
                 position = posMatrix * vertex.co
                 
-                # If face is smooth use vertex normal else use face normal
-                if face.use_smooth:
+                if mesh.use_auto_smooth:
+                    # if using Data->Normals->Auto Smooth, use split normal vector
+                    normal = Vector(face.split_normals[i])
+                elif face.use_smooth:
+                    # if face is smooth, use vertex normal
                     normal = vertex.normal
                 else:
+                    # use face normal
                     normal = face.normal
                 normal = normalMatrix * normal
 

--- a/io_mesh_urho/decompose.py
+++ b/io_mesh_urho/decompose.py
@@ -1602,6 +1602,10 @@ def DecomposeMesh(scene, meshObj, tData, tOptions, errorsMem):
                     continue
                 if textureData.image is None:
                     continue
+                # Skip disabled textures
+                textureIndex = material.texture_slots.find(texture.name)
+                if textureIndex >= 0 and not material.use_textures[textureIndex]:
+                    continue
                 imageName = textureData.image.name
                 if texture.use_map_color_diffuse:
                     tMaterial.diffuseTexName = imageName

--- a/io_mesh_urho/decompose.py
+++ b/io_mesh_urho/decompose.py
@@ -351,6 +351,7 @@ class TOptions:
         self.doTracks = False
         self.doTimeline = False
         self.doTriggers = False
+        self.doAnimationZero = True
         self.doAnimationPos = True
         self.doAnimationRot = True
         self.doAnimationSca = True
@@ -1239,6 +1240,11 @@ def DecomposeActions(scene, armatureObj, tData, tOptions):
             # For Tracks and Timeline we use the scene playback range
             startframe = int(scene.frame_start)
             endframe = int(scene.frame_end + 1)
+
+        # If we don't want (good idea) to use the frame zero as start, use the first keyframe 
+        # for Actions or the playback start for Tracks and the Timeline
+        if not tOptions.doAnimationZero:
+            frameOffset = startframe
 
         # Here we collect every action used by this animation, so we can filter the only used bones
         actionSet = set()

--- a/io_mesh_urho/decompose.py
+++ b/io_mesh_urho/decompose.py
@@ -1196,7 +1196,7 @@ def DecomposeActions(scene, armatureObj, tData, tOptions):
             if tOptions.doStrips or (tOptions.doSelectedStrips and strip.select):
                 stripLink = NlaStripLink(strip, previous, track)
                 animationObjects.append(stripLink)
-            # Add an used Action 
+            # Add an used Action
             action = strip.action
             if tOptions.doUsedActions and action and not action in animationObjects:
                 animationObjects.append(action)
@@ -1278,7 +1278,7 @@ def DecomposeActions(scene, armatureObj, tData, tOptions):
             armatureObj.animation_data.use_nla = True
             oldTrackValue = object.track.is_solo
             object.track.is_solo = True
-            # We mute the previous strip because it mess with the first frame
+            # We mute the previous strip because it makes a mess with the first frame
             if object.previous:
                 oldStripValue = object.previous.mute
                 object.previous.mute = True
@@ -1287,7 +1287,7 @@ def DecomposeActions(scene, armatureObj, tData, tOptions):
 
         # If it is the Timeline, merge all the Tracks (not muted)
         if isinstance(object, bpy.types.Object):
-            log.info("Decomposing animation: {:s} (frames {:.1f} {:.1f})".format(object.name, startframe, endframe-1))
+            log.info("Decomposing timeline: {:s} (frames {:.1f} {:.1f})".format(object.name, startframe, endframe-1))
             armatureObj.animation_data.use_nla = True
             # If there are no Tracks use the saved action (NLA is empty so we can keep it on)
             if not object.animation_data.nla_tracks and savedAction:
@@ -1350,7 +1350,7 @@ def DecomposeActions(scene, armatureObj, tData, tOptions):
             parent = poseBone.parent
         
             # For each frame
-            for time in range( startframe, endframe, scene.frame_step):
+            for time in range(startframe, endframe, scene.frame_step):
                 
                 if (progressCur % 40) == 0:
                     print("{:.3f}%\r".format(progressCur / progressTot), end='' )

--- a/io_mesh_urho/export_urho.py
+++ b/io_mesh_urho/export_urho.py
@@ -418,6 +418,8 @@ class UrhoTrigger:
         self.name = ""
         # Time in seconds: float
         self.time = None
+        # Time as ratio: float
+        self.ratio = None
         # Event data (variant, see typeNames[] in Variant.cpp)
         self.data = None
 
@@ -740,7 +742,10 @@ def UrhoWriteTriggers(triggersList, filename, fOptions):
 
     for trigger in triggersList:
         triggerElem = ET.SubElement(triggersElem, "trigger")
-        triggerElem.set("time", FloatToString(trigger.time))
+        if trigger.time is not None:
+            triggerElem.set("time", FloatToString(trigger.time))
+        if trigger.ratio is not None:
+            triggerElem.set("normalizedtime", FloatToString(trigger.ratio))
         # We use a string variant, for other types See typeNames[] in Variant.cpp 
         # and XMLElement::GetVariant()
         triggerElem.set("type", "String")
@@ -1211,7 +1216,10 @@ def UrhoExport(tData, uExportOptions, uExportData, errorsMem):
         for tTrigger in tAnimation.triggers:
             uTrigger = UrhoTrigger()
             uTrigger.name = tTrigger.name
-            uTrigger.time = tTrigger.time
+            if uExportOptions.useRatioTriggers:
+                uTrigger.ratio = tTrigger.ratio
+            else:
+                uTrigger.time = tTrigger.time
             uTrigger.data = tTrigger.data
             uAnimation.triggers.append(uTrigger)
                     

--- a/io_mesh_urho/export_urho.py
+++ b/io_mesh_urho/export_urho.py
@@ -801,6 +801,13 @@ def GetMaxElementMask(indices, vertices):
 
 def UrhoExport(tData, uExportOptions, uExportData, errorsMem):
 
+    global MAX_SKIN_MATRICES
+    global BONES_PER_VERTEX
+    if uExportOptions.bonesPerGeometry:
+        MAX_SKIN_MATRICES = uExportOptions.bonesPerGeometry
+    if uExportOptions.bonesPerVertex:
+        BONES_PER_VERTEX = uExportOptions.bonesPerVertex
+
     uModel = UrhoModel()
     uModel.name = tData.objectName
     uExportData.models.append(uModel)    

--- a/io_mesh_urho/export_urho.py
+++ b/io_mesh_urho/export_urho.py
@@ -414,7 +414,7 @@ class UrhoTrack:
 
 class UrhoTrigger:
     def __init__(self):
-         # Trigger name 
+        # Trigger name 
         self.name = ""
         # Time in seconds: float
         self.time = None
@@ -901,9 +901,9 @@ def UrhoExport(tData, uExportOptions, uExportData, errorsMem):
             # Set lod vertex and index buffers
             uLodLevel.vertexBuffer = len(uModel.vertexBuffers) - 1
             uLodLevel.indexBuffer = len(uModel.indexBuffers) - 1
-            print("Geometry{:d} LOD{:d} using: vertex buffer {:d} ({:d}), index buffer {:d} ({:d})"
-                  .format(geomIndex, lodIndex, uLodLevel.vertexBuffer, len(tLodLevel.indexSet),
-                  uLodLevel.indexBuffer, uLodLevel.countIndex))
+            ##print("Geometry{:d} LOD{:d} using: vertex buffer {:d} ({:d}), index buffer {:d} ({:d})"
+            ##      .format(geomIndex, lodIndex, uLodLevel.vertexBuffer, len(tLodLevel.indexSet),
+            ##      uLodLevel.indexBuffer, uLodLevel.countIndex))
             
             # Maps old vertex index to new vertex index in the new Urho buffer
             indexMap = {}


### PR DESCRIPTION
Installation 
• Download the script's tree and copy into "/your_blender/2.63/scripts/addons_contrib/io_export_dxf/" folder. 
• Open Blender and go to the addons tab in User Preferences. 
• Enable the script 
• Start from File > Export menu. 

 Features 

supported data: 
• mesh-face -> POLYFACE or 3DFACE 
• mesh-edge -> LINE 
• modifier (optionally) 

unsupported data: 
• mesh-vertex -> POINT 
• curve -> LINEs or POLYLINE 
• curve-NURBS -> curved-POLYLINE 
• text -> TEXT or (wip: MTEXT) 
• camera -> POINT or VIEW or VPORT or (wip: INSERT(ATTRIB+XDATA) 
• lamp -> POINT or (wip: INSERT(ATTRIB+XDATA) 
• empty -> POINT or (wip: INSERT) 
• obj.matrix -> extrusion(210-group), rotation, elevation 
• 3D-View -> (wip: VIEW, VPORT) 
• duplivert -> auto-instanced or (wip: INSERT) 
• dupliframe -> auto-instanced or (wip: INSERT) 
• dupligroup -> auto-instanced or (wip: INSERT) 
• material -> LAYER+COLOR+STYLE properties 
• group -> BLOCK+INSERT 
• parenting -> BLOCK+INSERT 
• visibility status -> LAYER_on 
• frozen status -> LAYER_frozen 
• locked status -> LAYER_locked 
• Surface 
• Meta 
• Armature 
• Lattice 
• IPO/Animation 
