### PR TITLE
Add remove single frames option

### DIFF
--- a/io_mesh_urho/__init__.py
+++ b/io_mesh_urho/__init__.py
@@ -321,6 +321,7 @@ class UrhoExportSettings(bpy.types.PropertyGroup):
         self.animationPos = True
         self.animationRot = True
         self.animationSca = False
+        self.filterSingleKeyFrames = False
 
         self.geometries = True
         self.geometryPos = True
@@ -616,6 +617,11 @@ class UrhoExportSettings(bpy.types.PropertyGroup):
     animationSca = BoolProperty(
             name = "Scale",
             description = "Within animations export bone scales",
+            default = False)
+
+    filterSingleKeyFrames = BoolProperty(
+            name = "Remove single tracks",
+            description = "Do not export tracks which contain only one keyframe, useful for layered animations",
             default = False)
 
     geometries = BoolProperty(
@@ -964,6 +970,7 @@ class UrhoExportRenderPanel(bpy.types.Panel):
             row.prop(settings, "animationPos")
             row.prop(settings, "animationRot")
             row.prop(settings, "animationSca")
+            column.prop(settings, "filterSingleKeyFrames")
         
         row = box.row()
         row.prop(settings, "geometries")
@@ -1244,6 +1251,7 @@ def ExecuteUrhoExport(context):
     tOptions.doAnimationPos = settings.animationPos
     tOptions.doAnimationRot = settings.animationRot
     tOptions.doAnimationSca = settings.animationSca
+    tOptions.filterSingleKeyFrames = settings.filterSingleKeyFrames
     tOptions.doGeometries = settings.geometries
     tOptions.doGeometryPos = settings.geometryPos
     tOptions.doGeometryNor = settings.geometryNor

--- a/io_mesh_urho/decompose.py
+++ b/io_mesh_urho/decompose.py
@@ -358,6 +358,7 @@ class TOptions:
         self.doAnimationPos = True
         self.doAnimationRot = True
         self.doAnimationSca = True
+        self.filterSingleKeyFrames = False
         self.doGeometries = True
         self.doGeometryPos = True
         self.doGeometryNor = True
@@ -1409,7 +1410,7 @@ def DecomposeActions(scene, armatureObj, tData, tOptions):
                 if not tTrack.frames or tTrack.frames[-1].hasMoved(tFrame):
                     tTrack.frames.append(tFrame)
                 
-            if tTrack.frames:
+            if tTrack.frames and (not tOptions.filterSingleKeyFrames or len(tTrack.frames) > 1):
                 tAnimation.tracks.append(tTrack)
 
         # Use timeline marker as Urho triggers


### PR DESCRIPTION
current exporter will add a keyframe to everyone bone in an action regardless of if it moves again. Urho3d layered animations will only allow lower animation bones to apply if there are no keyframes for the bones in the layer above. Added the option to strip out bones which only have 1 keyframe to allow layered animations to work.